### PR TITLE
Handle basket pickup after tailwind moves

### DIFF
--- a/main.html
+++ b/main.html
@@ -817,8 +817,10 @@
               const L = lanes[pc.r].L;
               const dir = pc.carrying ? -1 : +1;
               const ns = pc.step + dir;
-              if (ns >= 1 && ns <= L && !occupied(pc.r, pc.side, ns))
+              if (ns >= 1 && ns <= L && !occupied(pc.r, pc.side, ns)) {
                 pc.step = ns;
+                afterMovePickup(pc);
+              }
               finishTailwind();
             };
             hasOption = true;


### PR DESCRIPTION
## Summary
- ensure tailwind-advanced pieces collect basket if they land on its space
- prevents loss of carrying status and enables subsequent moves

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6634a705c832d81583a3fa64cdff8