### PR TITLE
Allow swoops when no lane moves available

### DIFF
--- a/main.html
+++ b/main.html
@@ -248,7 +248,6 @@ function renderScores(){ document.getElementById('score0').textContent=players[0
 /* ---------- Buttons enable/disable ---------- */
 function canSwoopThisRoll(){
   if(!(mode==='pairChosen' && selectedPair)) return false;
-  if(!existsAnyMoveThisRoll()) return false; // bust => no swoop
   const pl=players[current];
   const actives = pl.pieces.filter(p=>p.active);
   if(actives.length===0) return false;
@@ -394,7 +393,6 @@ function potentialSwoops(pc){
 }
 function usePairForSwoop(){
   if(!(mode==='pairChosen' && selectedPair)) return;
-  if(!existsAnyMoveThisRoll()){ toast('Swoop not allowed on a bust.'); return; }
   const pl=players[current];
   const actives = pl.pieces.filter(p=>p.active);
   if(actives.length===0){ toast('No active piece to Swoop.'); return; }


### PR DESCRIPTION
## Summary
- Permit swoops even when no lane move is possible, removing bust check dependency
- Simplify `usePairForSwoop` to only require an active piece and selected pair

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node` script verifying `canSwoopThisRoll()` returns `true` for provided state

------
https://chatgpt.com/codex/tasks/task_e_68a88796ec28832d8c98e2904319e762