### PR TITLE
Update package-lock with server dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "serverless-http": "^3.2.0",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.0.0",
@@ -2931,6 +2933,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/serverless-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
+      "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -3540,6 +3551,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {


### PR DESCRIPTION
## Summary
- update package-lock.json so serverless-http and ws dependencies are captured and in sync with package.json

## Testing
- npm ci --no-fund --no-audit *(terminated in the execution environment after a prolonged download attempt)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1b2f3318832d87421a5d833d868a